### PR TITLE
Handle 401s due to cookie encryption key renewal or idsvr redeployment

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -92,6 +92,11 @@ if [ $? -ne 0 ]; then
   exit
 fi
 
+# TODO: delete on merge
+cd resources
+git checkout feature/cors-refinements
+cd ..
+
 #
 # Build resources by running the child script
 #

--- a/build.sh
+++ b/build.sh
@@ -92,11 +92,6 @@ if [ $? -ne 0 ]; then
   exit
 fi
 
-# TODO: delete on merge
-cd resources
-git checkout feature/cors-refinements
-cd ..
-
 #
 # Build resources by running the child script
 #

--- a/spa/src/views/app/app.tsx
+++ b/spa/src/views/app/app.tsx
@@ -142,7 +142,8 @@ export default function App(props: AppProps) {
                 <MultiTabView />
 
                 <UserInfoView 
-                    oauthClient={props.viewModel.oauthClient!} />
+                    oauthClient={props.viewModel.oauthClient!}
+                    setIsLoggedOut={setIsLoggedOut} />
 
                 <CallApiView 
                     apiClient={props.viewModel.apiClient!}

--- a/spa/src/views/pageLoad/pageLoadView.tsx
+++ b/spa/src/views/pageLoad/pageLoadView.tsx
@@ -20,7 +20,22 @@ export function PageLoadView(props: PageLoadProps) {
             return {handled: false, isLoggedIn: false};
         }
 
-        return await props.oauthClient.handlePageLoad(location.href);
+        try {
+            return await props.oauthClient.handlePageLoad(location.href);
+
+        } catch (e) {
+
+            const remoteError = e as RemoteError;
+            if (remoteError && remoteError.getStatus() === 401) {
+
+                // A 401 could occur if there is a leftover cookie in the browser that can no longer be processed
+                // Eg if the cookie encryption key is renewed or if the Authorization Server data is redeployed
+                // In this case we return an unauthenticated state
+                return {handled: false, isLoggedIn: false};
+            }
+
+            throw e;
+        }
     }
 
     async function execute() {
@@ -50,7 +65,7 @@ export function PageLoadView(props: PageLoadProps) {
 
             const remoteError = e as RemoteError;
             if (remoteError) {
-            
+
                 setState((state: any) => {
                     return {
                         ...state,

--- a/spa/src/views/signOut/signOutView.tsx
+++ b/spa/src/views/signOut/signOutView.tsx
@@ -25,12 +25,23 @@ export function SignOutView(props: SignOutProps) {
 
             const remoteError = e as RemoteError;
             if (remoteError) {
-                setState((state: any) => {
-                    return {
-                        ...state,
-                        error: remoteError.toDisplayFormat(),
-                    };
-                });
+
+                if (remoteError.getStatus() === 401) {
+
+                    // A 401 could occur if there is a leftover cookie in the browser that can no longer be processed
+                    // Eg if the cookie encryption key is renewed or if the Authorization Server data is redeployed
+                    // In this case we return to an unauthenticated state
+                    props.setIsLoggedOut();
+
+                } else {
+
+                    setState((state: any) => {
+                        return {
+                            ...state,
+                            error: remoteError.toDisplayFormat(),
+                        };
+                    });
+                }
             }
         }
     }

--- a/spa/src/views/userInfo/userInfoProps.ts
+++ b/spa/src/views/userInfo/userInfoProps.ts
@@ -2,4 +2,5 @@ import {OAuthClient} from '../../oauth/oauthClient';
 
 export interface UserInfoProps {
     oauthClient: OAuthClient;
+    setIsLoggedOut: () => void;
 }

--- a/spa/src/views/userInfo/userInfoView.tsx
+++ b/spa/src/views/userInfo/userInfoView.tsx
@@ -42,12 +42,22 @@ export function UserInfoView(props: UserInfoProps) {
             const remoteError = e as RemoteError;
             if (remoteError) {
 
-                setState((state: any) => {
-                    return {
-                        ...state,
-                        error: remoteError.toDisplayFormat(),
-                    };
-                });
+                if (remoteError.getStatus() === 401) {
+
+                    // A 401 could occur if there is a leftover cookie in the browser that can no longer be processed
+                    // Eg if the cookie encryption key is renewed or if the Authorization Server data is redeployed
+                    // In this case we return to an unauthenticated state
+                    props.setIsLoggedOut();
+
+                } else {
+
+                    setState((state: any) => {
+                        return {
+                            ...state,
+                            error: remoteError.toDisplayFormat(),
+                        };
+                    });
+                }
             }
         }
     }


### PR DESCRIPTION
Previously the SPA dealt with 401s during API calls and returned to the unauthenticated view.
However, it did not cope with redeployment of the idsvr or encryption key renewal.
So I have made some small changes so that on 401 the SPA returns to the unauthenticated view:
- Page load
- Get User Info
- Logout
All part of demonstrating reliability.